### PR TITLE
Add backend caching with caffeine

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ group = "no.bekk"
 version = "0.0.1"
 application {
     mainClass.set("no.bekk.ApplicationKt")
-    mainClassName = "no.bekk.ApplicationKt"
+    mainClassName = "no.bekk.ApplicationKt" // Need this while shadow plugin < 7
 }
 
 repositories {
@@ -36,6 +36,7 @@ dependencies {
     implementation("org.postgresql:postgresql:42.2.23")
     implementation("com.google.cloud.sql:postgres-socket-factory:1.3.3")
     implementation("org.flywaydb:flyway-core:8.0.0-beta2")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.0.4")
     testImplementation("io.ktor:ktor-server-tests:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
     testImplementation("com.h2database:h2:1.3.148")

--- a/src/main/kotlin/no/bekk/SanityClient.kt
+++ b/src/main/kotlin/no/bekk/SanityClient.kt
@@ -1,3 +1,5 @@
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.features.*
@@ -5,10 +7,11 @@ import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
 import no.bekk.EndringJson
+import java.util.concurrent.TimeUnit
 
 sealed class Result<out T, out E>
-class Ok<out T>(val value: T): Result<T, Nothing>()
-class Err<out E>(val error: E): Result<Nothing, E>()
+class Ok<out T>(val value: T) : Result<T, Nothing>()
+class Err<out E>(val error: E) : Result<Nothing, E>()
 
 class SanityClient(
     val projId: String,
@@ -28,14 +31,48 @@ class SanityClient(
         }
     }
 
-    suspend fun query(query: String): Result<EndringJson, ClientRequestException> {
+    suspend fun query(queryString: String): Result<EndringJson, ClientRequestException> {
+        return tryCacheFirst(queryCache, queryString) { q -> querySanity(q) }
+    }
+
+    private val queryCache: Cache<String, EndringJson> = Caffeine.newBuilder()
+        .expireAfterWrite(1, TimeUnit.MINUTES)
+        .maximumSize(1000)
+        .build()
+
+    private suspend fun querySanity(queryString: String): Result<EndringJson, ClientRequestException> {
         val response: EndringJson
         return try {
-            response = client.get("$baseUrl/data/query/$dataset?query=$query")
+            response = client.get("$baseUrl/data/query/$dataset?query=$queryString")
             Ok(response)
-        } catch (e: ClientRequestException){
+        } catch (e: ClientRequestException) {
             print("Received client request exception with error code ${e.response} and message ${e.message}")
             Err(e)
+        }
+    }
+
+    private suspend fun <K, V> tryCacheFirst(
+        cache: Cache<K, V>,
+        key: K,
+        valueSupplier: suspend (queryString: K) -> Result<V, ClientRequestException>
+    ): Result<V, ClientRequestException> {
+        val value = cache.getIfPresent(key)
+        return if (value == null) {
+            when (val newValue = valueSupplier(key)) {
+                is Ok -> {
+                    cache.put(key, newValue.value)
+                    newValue
+                }
+                is Err -> {
+                    newValue
+                }
+                /* else clause should not be needed, kotlin language bug
+                 * https://youtrack.jetbrains.com/issue/KT-35784
+                 */
+                else -> newValue
+            }
+        } else {
+            Ok(value)
         }
     }
 }

--- a/src/main/kotlin/no/bekk/SanityClient.kt
+++ b/src/main/kotlin/no/bekk/SanityClient.kt
@@ -37,7 +37,7 @@ class SanityClient(
 
     private val queryCache: Cache<String, EndringJson> = Caffeine.newBuilder()
         .expireAfterWrite(1, TimeUnit.MINUTES)
-        .maximumSize(1000)
+        .maximumSize(50)
         .build()
 
     private suspend fun querySanity(queryString: String): Result<EndringJson, ClientRequestException> {

--- a/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -16,9 +16,8 @@ fun Application.configureRouting(client: SanityClient) {
         post("/endringslogg") {
             val (userId, appId, maxEntries) = call.receive<BrukerData>()
             val entries = getSeenEntriesForUser(userId).map(UUID::toString).toSet()
-            val endringslogger = client.query("*[_type == '$appId'][0...$maxEntries]")
 
-            when(endringslogger) {
+            when(val endringslogger = client.query("*[_type == '$appId'][0...$maxEntries]")) {
                 is Ok -> {
                     if (endringslogger.value.result.isEmpty()){
                         call.response.status(HttpStatusCode(204, "Data for app $appId doesn't exist."))


### PR DESCRIPTION
Add backend caching of sanity queries using caffeine.
With current config, query result is stored for a hot minute before being cleared.
This should hopefully improve response rate a bit.