### PR TITLE
Eksplisitt navngiving av sqlInstances

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -9,7 +9,8 @@ spec:
   image: {{ image }}
   gcp:
     sqlInstances:
-      - type: POSTGRES_14
+      - name: endringslogg
+        type: POSTGRES_14
         databases:
           - envVarPrefix: DB
             name: poao-endringslogg

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -9,9 +9,10 @@ spec:
   image: {{ image }}
   gcp:
     sqlInstances:
-      - type: POSTGRES_14
+      - name: endringslogg-v2
+        type: POSTGRES_14
         databases:
           - envVarPrefix: DB
-            name: poao-endringslogg-v2
+            name: poao-endringslogg
   ingresses:
     - https://poao-endringslogg.intern.nav.no


### PR DESCRIPTION
Default navn for sqlInstances er navn på applikasjonen. Kan ikke gjenbruke navn før en uke etter sletting, derfor v2 i prod pga oppgradering av postgres fra 12 til 14. Kan beholde navn på databasen som før.