### PR TITLE
Fikse feil der appen ikke klarte å nå Sanity

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -15,6 +15,10 @@ spec:
       rules:
         - application: veilarbportefoljeflatefs
           namespace: obo
+    outbound:
+      external:
+        - host: li581mqu.api.sanity.io
+        - host: cdn.sanity.io
   gcp:
     sqlInstances:
       - name: endringslogg-v3

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -15,6 +15,10 @@ spec:
       rules:
         - application: veilarbportefoljeflatefs
           namespace: obo
+    outbound:
+      external:
+        - host: li581mqu.api.sanity.io
+        - host: cdn.sanity.io
   gcp:
     sqlInstances:
       - name: endringslogg-v3

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @navikt/obo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM navikt/java:11
+FROM ghcr.io/navikt/poao-baseimages/java:11
 COPY ./build/libs/*all.jar "app.jar"
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"


### PR DESCRIPTION
Vi er nødt til å spesifisere eksplisitt hvilke eksterne host-er som appen skal snakke med, ref: [Håndheving av egress-policy i gcp-clustere](https://nav-it.slack.com/archives/C01DE3M9YBV/p1679409522527339).