### PR TITLE
Bytt til "nais/docker-build-push"-action

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: pto
 spec:
-  image: {{ image }}
+  image: {{image}}
   azure:
     application:
       enabled: true

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: pto
 spec:
-  image: {{ image }}
+  image: {{image}}
   azure:
     application:
       enabled: true

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -5,9 +5,6 @@ on:
       - dev
   workflow_dispatch:
 
-env:
-  IMAGE: ghcr.io/navikt/poao-endringslogg:${{ github.sha }}
-
 permissions:
   packages: write
 
@@ -15,36 +12,47 @@ jobs:
   build:
     name: Build and push package
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    permissions:
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
+
       - name: Bygg med Gradle
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew shadowJar
-      - name: Build and publish Docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo ${GITHUB_TOKEN} | docker login ghcr.io --username ${GITHUB_REPOSITORY} --password-stdin
-          docker build --tag ${IMAGE} .
-          docker push ${IMAGE}
+
+      - name: Build and push Docker image
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: pto
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+
   deploy:
     name: Deploy to dev-gcp
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Deploy til dev-gcp
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais-dev.yaml
+          VAR: image=${{ needs.build.outputs.image }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,9 +5,6 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  IMAGE: ghcr.io/navikt/poao-endringslogg:${{ github.sha }}
-
 permissions:
   packages: write
 
@@ -15,37 +12,48 @@ jobs:
   build:
     name: Build and push package
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    permissions:
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
+
       - name: Bygg med Gradle
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew shadowJar
-      - name: Build and publish Docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo ${GITHUB_TOKEN} | docker login ghcr.io --username ${GITHUB_REPOSITORY} --password-stdin
-          docker build --tag ${IMAGE} .
-          docker push ${IMAGE}
+
+      - name: Build and push Docker image
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: pto
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+
   deploy:
     name: Deploy to prod-gcp
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Deploy til prod-gcp
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais-prod.yaml
+          VAR: image=${{ needs.build.outputs.image }}


### PR DESCRIPTION
Bytter fra `docker/build-push-action` GitHub action til å bruke NAIS sin `nais/docker-build-push` GitHub action. Dette gir oss en del fordeler blant annet mtp. stabilitet ved image-pulls da `nais/docker-build-push` går mot Google Artifact Registry (GAR) i stedet for GitHub Container Registry (GHCR), samt automatisk signering/scanning av Docker images via SALSA.

Det står en god del om dette i NAIS-docen, bla.a. [Salsa - NAIS](https://doc.nais.io/security/salsa/salsa) og [OCI registry migration - NAIS](https://doc.nais.io/guides/oci-migration/). Noen relevante utdrag:

> [SLSA](https://slsa.dev/) is short for Supply chain Levels for Software Artifacts pronounced salsa.
>
> It is a security framework, essentially a checklist comprising standards and controls aimed at preventing tampering, enhancing integrity, and securing both packages and infrastructure within our projects.

> If you utilize the [nais/docker-build-push](https://github.com/nais/docker-build-push) action for building and pushing your container image, you will automatically receive a signed attestation/SBOM (Software Bill of Materials) for your container image and its dependencies. 
>
> This SBOM will be uploaded to your container registry along with your image. The attestation is generated by the [Trivy](https://github.com/aquasecurity/trivy-action) GitHub action and signed using [cosign](https://github.com/sigstore/cosign).

> Upon deploying your image to NAIS, the attestation will undergo verification by the NAIS platform ([picante](https://github.com/nais/picante)) and will be uploaded to an SBOM analysis platform known as [Dependency-Track](https://dependencytrack.org/). In Dependency-Track, you can examine the attestation as well as the vulnerabilities present in your image and its dependencies.

> GHCR serves as a OCI registry hosted by GitHub, but it has certain limitations, such as imposing strict rate limits on the number of requests. We've encountered challenges with these rate limits, particularly when upgrading a cluster or restoring from a backup. In such instances, we've had to patiently wait for the rate limits to reset before deploying / restoring our applications.
>
> On the other hand, GAR is a OCI registry hosted by Google, and we find it to be a more favorable solution for our needs. Additionally, as we transition to the cloud, the seamless integration with the Google Cloud Platform further enhances its appeal as a beneficial option for our operations.

## Trello ticket number and link

- [TC-380](https://trello.com/c/9wLGC3Tp/380-bytte-fra-snyk-til-github-advanced-security)
